### PR TITLE
Increase version of react-native-scrollable-tab-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Native Emoticons
+# React Native a2s Emoticons
 react native emoticons component, including emoji
 
 ![emoticons](docs/emoticons.gif)
@@ -10,7 +10,7 @@ react native emoticons component, including emoji
 ## Install
 
 ```js
-npm install react-native-emoticons
+npm install react-native-a2s-emoticons
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ npm install react-native-emoticons
 	Import the component package.
 	
 	```js
-	import Emoticons from 'react-native-emoticons';
+	import Emoticons from 'react-native-a2s-emoticons';
 	```
 - step 2
 
@@ -57,7 +57,7 @@ npm install react-native-emoticons
 Import
 
 ```js
-import * as emoticons from 'react-native-emoticons';
+import * as emoticons from 'react-native-a2s-emoticons';
 ```
 
 1. stringify
@@ -104,3 +104,5 @@ import * as emoticons from 'react-native-emoticons';
 ## Further
 	
 ###	Support custom emoticons like `weixin`
+
+### Forked from [react-native-emoticons](https://github.com/xiewang/react-native-emoticons)

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ require('string.fromcodepoint');
 
 const categories = ['People', 'Nature', 'Foods', 'Activity', 'Places', 'Objects', 'Symbols', 'Flags'];
 const filters = ['white_frowning_face'];
-const blockIconNum = 23;
+const blockIconNum = 24;
 let choiceness = ['grinning', 'grin', 'joy', 'sweat_smile', 'laughing', 'wink', 'blush', 'yum', 'heart_eyes', 'kissing_heart',
     'kissing_smiling_eyes', 'stuck_out_tongue_winking_eye', 'sunglasses', 'smirk', 'unamused', 'thinking_face',
     'flushed', 'rage', 'triumph', 'sob', 'mask', 'sleeping', 'zzz', 'hankey', 'ghost', '+1', '-1', 'facepunch', 'v',
@@ -239,18 +239,6 @@ class Emoticons extends React.Component {
                                     );
 
                             })
-                        }
-                        {
-                            (this.props.asyncRender && this.state.currentDotTab[this.state.currentMainTab] == i)
-                            || !this.props.asyncRender ? (<TouchableOpacity
-                                onPress={()=>this._onBackspacePress()}
-                                style={[styles.emojiTouch, styles.delete]}
-                                >
-                                <Image
-                                    resizeMode={'contain'}
-                                    style={styles.backspace}
-                                    source={require('./backspace.png')}/>
-                            </TouchableOpacity>) : null
                         }
 
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-emoticons",
+  "name": "react-native-a2s-emoticons",
   "version": "1.1.0",
   "description": "react native emoticons component",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/xiewang/react-native-emoticons.git"
+    "url": "https://github.com/App2Sales/react-native-emoticons"
   },
   "keywords": [
     "react-native",
@@ -18,9 +18,9 @@
   "author": "xiewang",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/xiewang/react-native-emoticons/issues"
+    "url": "https://github.com/App2Sales/react-native-emoticons/issues"
   },
-  "homepage": "https://github.com/xiewang/react-native-emoticons",
+  "homepage": "https://github.com/App2Sales/react-native-emoticons",
   "dependencies": {
     "emoji-datasource": "^2.4.4",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-a2s-emoticons",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "react native emoticons component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "emoji-datasource": "^2.4.4",
     "lodash": "^4.17.4",
-    "react-native-scrollable-tab-view": "^0.8.0",
+    "react-native-scrollable-tab-view": "^0.10.0",
     "create-react-class": "^15.6.3",
     "string.fromcodepoint": "^0.2.1",
     "react-native-fetch-blob": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "emoji-datasource": "^2.4.4",
     "lodash": "^4.17.4",
-    "react-native-scrollable-tab-view": "^0.6.7",
+    "react-native-scrollable-tab-view": "^0.8.0",
+    "create-react-class": "^15.6.3",
     "string.fromcodepoint": "^0.2.1",
     "react-native-fetch-blob": "^0.10.5",
     "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-emoticons",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "react native emoticons component",
   "main": "index.js",
   "scripts": {

--- a/style.js
+++ b/style.js
@@ -20,18 +20,18 @@ const styles = StyleSheet.create({
         backgroundColor: '#fff',
         height: height,
         width: width,
-        position: 'absolute',
         bottom: 0,
         left:0,
         zIndex:1000
     },
     container: {
         backgroundColor: '#fff',
-        height: 300,
+        height: 200,
         width: width,
-        position: 'absolute',
         bottom: 0,
         left:0,
+        borderTopColor: '#9b9b9b',
+        borderTopWidth: 1
     },
     emoji: {
         textAlign: 'center',
@@ -40,8 +40,8 @@ const styles = StyleSheet.create({
         color: '#rgba(0,0,0,1)'
     },
     emojiTouch:{
-        width: (width-30)/6,
-        height: 50,
+        width: (width-30)/8,
+        height: 44,
         justifyContent: 'center',
         alignItems: 'center'
     },
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
         width: width
     },
     scrollGroupTable: {
-        paddingBottom: 50
+        paddingBottom: 40
     },
     cateView: {
         flex: 1,
@@ -62,21 +62,21 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'space-between',
         flexWrap: 'wrap',
-        paddingLeft: 15,
-        paddingRight: 15,
-        paddingTop: 15
+        paddingLeft: 8,
+        paddingRight: 8,
+        paddingTop: 8
     },
     tab: {
         alignItems: 'center',
         justifyContent: 'center',
         paddingBottom: 0,
-        width: 60,
+        width: 42,
         borderRightWidth: 1,
         borderColor: 'rgba(178,178,178,.3)',
         backgroundColor: '#fff'
     },
     tabs: {
-        height: 40,
+        height: 35,
         width: width,
         flexDirection: 'row',
         borderWidth: 1,
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(255,255,255,1)',
     },
     tabsDot: {
-        height: 40,
+        height: 8,
         width: width,
         flexDirection: 'row',
         borderWidth: 0,
@@ -95,19 +95,19 @@ const styles = StyleSheet.create({
         alignItems: 'center'
     },
     tabDot: {
-        width: 10,
-        height: 10,
-        borderRadius: 5,
-        alignItems: 'center',
-        justifyContent: 'center',
-        marginLeft: 5,
-        marginRight: 5
-    },
-    dot: {
-        backgroundColor: '#f1f1f1',
         width: 6,
         height: 6,
         borderRadius: 3,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginLeft: 3,
+        marginRight: 3
+    },
+    dot: {
+        backgroundColor: '#f1f1f1',
+        width: 4,
+        height: 4,
+        borderRadius: 2,
     },
     backspace:{
         width:30,

--- a/tab.js
+++ b/tab.js
@@ -11,6 +11,7 @@ import {
     DeviceEventEmitter
 } from 'react-native';
 import styles from './style';
+import PropTypes from 'prop-types';
 
 class TabBar extends React.Component {
     constructor(props) {
@@ -25,9 +26,9 @@ class TabBar extends React.Component {
 
 
     static propTypes = {
-        goToPage: React.PropTypes.func,
-        activeTab: React.PropTypes.number,
-        tabs: React.PropTypes.array,
+        goToPage: PropTypes.func,
+        activeTab: PropTypes.number,
+        tabs: PropTypes.array,
     };
 
     componentDidMount() {


### PR DESCRIPTION
from `"react-native-scrollable-tab-view": "^0.8.0",` to `"react-native-scrollable-tab-view": "^0.10.0",`

> bundling failed: SyntaxError: /Users/gerenciagram/Developer/react-native/app-gerenciagram/node_modules/react-native-scrollable-tab-view/SceneComponent.js: A trailing comma is not permitted after the rest element (9:32)

> const SceneComponent = (Props) => {
> >  9 |   const {shouldUpdated, ...props, } = Props;
>      |                                 ^
>   10 |   return <View {...props}>
>   11 |       <StaticContainer shouldUpdate={shouldUpdated}>
>   12 |         {props.children}

the old version is causing an error because of the comma in the react-native-tab-view file line